### PR TITLE
Replace inaccurate "released ten years ago" with "2002"

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -69,7 +69,7 @@ permalink: /
 					<div class="part">
 						<i class="mdi mdi-check-all"></i>
 						<h3>Maintained</h3>
-						<p>Munin's first version was released ten years ago and it has kept evolving since</p>
+						<p>Munin's first version was released in 2002 and it has kept evolving since</p>
 					</div>
 				</div>
             </div>


### PR DESCRIPTION
I like the new website; I think it clearly conveys Munin's value.  Thanks for your work on it.

This PR makes a minor wording tweak — according to an older draft of the front page (70a203db23506ee7909cec54e78647d1eb83e574), and according to the copyright date in https://github.com/munin-monitoring/munin/commit/19da12f, Munin is currently almost 19 years old (rather than 10 as the front page currently says).